### PR TITLE
Fix bug where default values were incorrectly loaded from storage

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -82,6 +82,8 @@ public class MainApp extends Application {
             addressBookOptional = storage.readAddressBook();
             if (!addressBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample AddressBook");
+            } else {
+                logger.info("AddressBook successfully loaded from storage");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
@@ -147,6 +149,9 @@ public class MainApp extends Application {
         UserPrefs initializedPrefs;
         try {
             Optional<UserPrefs> prefsOptional = storage.readUserPrefs();
+            if (prefsOptional.isPresent()) {
+                logger.info("Successfully loaded UserPrefs with values " + prefsOptional.get().toString());
+            }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataConversionException e) {
             logger.warning("UserPrefs file at " + prefsFilePath + " is not in the correct format. "

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -28,28 +28,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     private final UniqueEntityList<Person> persons;
     private final UniqueEntityList<Issue> issues;
 
-    /*
-     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
-     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
-     *
-     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
-     *   among constructors.
-     */
-    //    {
-    //        clients = new UniqueEntityList<Client>();
-    //        projects = new UniqueEntityList<Project>();
-    //        persons = new UniqueEntityList<Person>();
-    //        issues = new UniqueEntityList<Issue>();
-    //    }
-
     /**
      * Creates an empty addressbook
      */
     public AddressBook() {
-        clients = new UniqueEntityList<Client>();
-        projects = new UniqueEntityList<Project>();
-        persons = new UniqueEntityList<Person>();
-        issues = new UniqueEntityList<Issue>();
+        clients = new UniqueEntityList<>();
+        projects = new UniqueEntityList<>();
+        persons = new UniqueEntityList<>();
+        issues = new UniqueEntityList<>();
     }
 
     /**
@@ -107,6 +93,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     //// client-level operations
+
+    /**
+     * Sorts client list by <code>ClientId</code>
+     *
+     */
+    public void sortClientListById() {
+        clients.sortById();
+    }
 
     /**
      * Returns true if a client with the same identity as {@code client} exists in the address book.
@@ -344,4 +338,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         // TODO: Check for appropriate hashcode
         return clients.hashCode();
     }
+
+
 }

--- a/src/main/java/seedu/address/model/Deadline.java
+++ b/src/main/java/seedu/address/model/Deadline.java
@@ -30,6 +30,11 @@ public class Deadline {
         public String uiRepresentation() {
             return "No Deadline Set";
         }
+
+        @Override
+        public String toString() {
+            return "";
+        }
     }
 
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/seedu/address/model/Name.java
+++ b/src/main/java/seedu/address/model/Name.java
@@ -39,7 +39,7 @@ public class Name {
     public static class EmptyName extends Name {
         public static final Name EMPTY_NAME = new EmptyName();
         public EmptyName() {
-            super("abcdefg");
+            super("empty");
         }
 
         /**
@@ -49,6 +49,11 @@ public class Name {
         @Override
         public boolean isEmpty() {
             return true;
+        }
+
+        @Override
+        public String toString() {
+            return "";
         }
     }
 

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -99,6 +99,11 @@ public class Client implements ComparableByName<Client>, HasIntegerIdentifier<Cl
             return true;
         }
 
+        @Override
+        public String toString() {
+            return "";
+        }
+
     }
 
 

--- a/src/main/java/seedu/address/model/client/ClientEmail.java
+++ b/src/main/java/seedu/address/model/client/ClientEmail.java
@@ -53,6 +53,16 @@ public class ClientEmail {
             super("cs2103@nus.edu");
         }
 
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public String uiRepresentation() {
+            return "No email set";
+        }
+
     }
 
     /**
@@ -90,7 +100,7 @@ public class ClientEmail {
      * Returns the email of the client.
      * @return String representing email
      */
-    public String getEmailRepresentation() {
+    public String uiRepresentation() {
         return "Email: " + this.email;
     }
 

--- a/src/main/java/seedu/address/model/client/ClientId.java
+++ b/src/main/java/seedu/address/model/client/ClientId.java
@@ -51,6 +51,11 @@ public class ClientId {
         public boolean isEmpty() {
             return true;
         }
+
+        @Override
+        public String toString() {
+            return "";
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/ClientPhone.java
+++ b/src/main/java/seedu/address/model/client/ClientPhone.java
@@ -42,6 +42,16 @@ public class ClientPhone {
         public boolean isEmpty() {
             return true;
         }
+
+        @Override
+        public String uiRepresentation() {
+            return "No contact number set";
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
     }
 
     /**
@@ -63,7 +73,7 @@ public class ClientPhone {
      * Returns the phone of the client.
      * @return String representing phone
      */
-    public String getPhoneRepresentation() {
+    public String uiRepresentation() {
         return "Contact: " + this.phone;
     }
 

--- a/src/main/java/seedu/address/model/issue/Description.java
+++ b/src/main/java/seedu/address/model/issue/Description.java
@@ -15,12 +15,17 @@ public class Description {
         public static final Description EMPTY_DESCRIPTION = new EmptyDescription();
 
         private EmptyDescription() {
-            super("there's nothing");
+            super("empty");
         }
 
         @Override
         public boolean isEmpty() {
             return true;
+        }
+
+        @Override
+        public String toString() {
+            return "";
         }
     }
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/seedu/address/model/issue/Issue.java
+++ b/src/main/java/seedu/address/model/issue/Issue.java
@@ -64,6 +64,11 @@ public class Issue implements ComparableByName<Issue>, HasIntegerIdentifier<Issu
             return true;
         }
 
+        @Override
+        public String toString() {
+            return "";
+        }
+
     }
 
     public IssueId getIssueId() {

--- a/src/main/java/seedu/address/model/issue/IssueId.java
+++ b/src/main/java/seedu/address/model/issue/IssueId.java
@@ -37,6 +37,11 @@ public class IssueId {
         public boolean isEmpty() {
             return true;
         }
+
+        @Override
+        public String toString() {
+            return "";
+        }
     }
 
     public int getIdInt() {

--- a/src/main/java/seedu/address/model/issue/Priority.java
+++ b/src/main/java/seedu/address/model/issue/Priority.java
@@ -11,22 +11,36 @@ public enum Priority {
     public static final String MESSAGE_CONSTRAINTS = "Priority should be an integer 0, 1 or 2";
 
     /**
-     * Checks if the priority string is valid.
-     * @param priority
-     * @return Boolean denoting whether the priority string is valid.
+     * Checks if the priority integer string is valid.
+     * @param priorityValue
+     * @return Boolean denoting whether the priority integer string is valid.
      */
-    public static boolean isValidPriority(String priority) {
+    public static boolean isValidPriority(String priorityValue) {
 
         ArrayList<Integer> priorities = new ArrayList<Integer>();
         priorities.add(0);
         priorities.add(1);
         priorities.add(2);
         for (Integer i: priorities) {
-            if (Integer.valueOf(i).equals(Integer.valueOf(priority))) {
+            if (Integer.valueOf(i).equals(Integer.valueOf(priorityValue))) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if priority string is valid.
+     * @param priority
+     * @return Boolean denoting whether the priority integer string is valid.
+     */
+    public static boolean isValidPriorityString(String priority) {
+        try {
+            Priority tempPriority = valueOf(priority);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     public String uiRepresentation() {

--- a/src/main/java/seedu/address/model/list/UniqueEntityList.java
+++ b/src/main/java/seedu/address/model/list/UniqueEntityList.java
@@ -3,6 +3,7 @@ package seedu.address.model.list;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -151,5 +152,9 @@ public class UniqueEntityList<T extends ComparableByName<T> & HasIntegerIdentifi
             }
         }
         throw new NotFoundException();
+    }
+
+    public void sortById() {
+        internalList.sort(Comparator.comparingInt(HasIntegerIdentifier::getID));
     }
 }

--- a/src/main/java/seedu/address/model/project/Project.java
+++ b/src/main/java/seedu/address/model/project/Project.java
@@ -76,6 +76,11 @@ public class Project implements ComparableByName<Project>, HasIntegerIdentifier<
             return true;
         }
 
+        @Override
+        public String toString() {
+            return "";
+        }
+
     }
 
     public ProjectId getProjectId() {

--- a/src/main/java/seedu/address/model/project/ProjectId.java
+++ b/src/main/java/seedu/address/model/project/ProjectId.java
@@ -48,6 +48,11 @@ public class ProjectId {
         public boolean isEmpty() {
             return true;
         }
+
+        @Override
+        public String toString() {
+            return "";
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/project/Repository.java
+++ b/src/main/java/seedu/address/model/project/Repository.java
@@ -26,6 +26,11 @@ public class Repository {
         public boolean isEmpty() {
             return true;
         }
+
+        @Override
+        public String toString() {
+            return "";
+        }
     }
 
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -54,9 +54,6 @@ class JsonAdaptedClient {
         phone = source.getClientPhone().toString();
         email = source.getClientEmail().toString();
         clientId = source.getClientId().toString();
-        //        projects.addAll(source.getProjects().stream()
-        //                .map(JsonAdaptedProject::new)
-        //                .collect(Collectors.toList()));
     }
 
     /**
@@ -66,35 +63,49 @@ class JsonAdaptedClient {
      */
     public Client toModelType() throws IllegalValueException {
         final List<Project> clientProjects = new ArrayList<>();
-        //        for (JsonAdaptedProject project : projects) {
-        //            clientProjects.add(project.toModelType());
-        //        }
+
+        if (name.isEmpty()) {
+            return Client.EmptyClient.EMPTY_CLIENT;
+        }
 
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
+
         if (!Name.isValidName(name)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
         final Name modelName = new Name(name);
 
-        if (phone == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    ClientPhone.class.getSimpleName()));
-        }
-        if (!ClientPhone.isValidClientPhone(phone)) {
-            throw new IllegalValueException(ClientPhone.MESSAGE_CONSTRAINTS);
-        }
-        final ClientPhone modelPhone = new ClientPhone(phone);
+        ClientPhone modelPhone;
 
-        if (email == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    ClientEmail.class.getSimpleName()));
+        if (phone.isEmpty()) {
+            modelPhone = ClientPhone.EmptyClientPhone.EMPTY_PHONE;
+        } else {
+            if (phone == null) {
+                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                        ClientPhone.class.getSimpleName()));
+            }
+            if (!ClientPhone.isValidClientPhone(phone)) {
+                throw new IllegalValueException(ClientPhone.MESSAGE_CONSTRAINTS);
+            }
+            modelPhone = new ClientPhone(phone);
         }
-        if (!ClientEmail.isValidEmail(email)) {
-            throw new IllegalValueException(ClientEmail.MESSAGE_CONSTRAINTS);
+
+        ClientEmail modelEmail;
+
+        if (email.isEmpty()) {
+            modelEmail = ClientEmail.EmptyEmail.EMPTY_EMAIL;
+        } else {
+            if (email == null) {
+                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                        ClientEmail.class.getSimpleName()));
+            }
+            if (!ClientEmail.isValidEmail(email)) {
+                throw new IllegalValueException(ClientEmail.MESSAGE_CONSTRAINTS);
+            }
+            modelEmail = new ClientEmail(email);
         }
-        final ClientEmail modelEmail = new ClientEmail(email);
 
         if (clientId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -64,12 +64,12 @@ class JsonAdaptedClient {
     public Client toModelType() throws IllegalValueException {
         final List<Project> clientProjects = new ArrayList<>();
 
-        if (name.isEmpty()) {
-            return Client.EmptyClient.EMPTY_CLIENT;
-        }
-
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+
+        if (name.isEmpty()) {
+            return Client.EmptyClient.EMPTY_CLIENT;
         }
 
         if (!Name.isValidName(name)) {
@@ -79,13 +79,14 @@ class JsonAdaptedClient {
 
         ClientPhone modelPhone;
 
+        if (phone == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    ClientPhone.class.getSimpleName()));
+        }
+
         if (phone.isEmpty()) {
             modelPhone = ClientPhone.EmptyClientPhone.EMPTY_PHONE;
         } else {
-            if (phone == null) {
-                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                        ClientPhone.class.getSimpleName()));
-            }
             if (!ClientPhone.isValidClientPhone(phone)) {
                 throw new IllegalValueException(ClientPhone.MESSAGE_CONSTRAINTS);
             }
@@ -94,13 +95,14 @@ class JsonAdaptedClient {
 
         ClientEmail modelEmail;
 
+        if (email == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    ClientEmail.class.getSimpleName()));
+        }
+
         if (email.isEmpty()) {
             modelEmail = ClientEmail.EmptyEmail.EMPTY_EMAIL;
         } else {
-            if (email == null) {
-                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                        ClientEmail.class.getSimpleName()));
-            }
             if (!ClientEmail.isValidEmail(email)) {
                 throw new IllegalValueException(ClientEmail.MESSAGE_CONSTRAINTS);
             }
@@ -111,14 +113,14 @@ class JsonAdaptedClient {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     ClientId.class.getSimpleName()));
         }
+
         if (!ClientId.isValidClientId(clientId)) {
             throw new IllegalValueException(ClientId.MESSAGE_CONSTRAINTS);
         }
 
         final ClientId modelClientId = new ClientId(Integer.parseInt(clientId));
-        if (modelClientId.getIdInt() == -1) {
-            return Client.EmptyClient.EMPTY_CLIENT;
-        }
+
+        assert modelClientId.getIdInt() >= 0 : "Client ID should be positive";
 
         return new Client(modelName, modelPhone, modelEmail, clientProjects, modelClientId);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedIssue.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedIssue.java
@@ -11,7 +11,9 @@ import seedu.address.model.issue.Issue;
 import seedu.address.model.issue.IssueId;
 import seedu.address.model.issue.Priority;
 import seedu.address.model.issue.Status;
+import seedu.address.model.list.NotFoundException;
 import seedu.address.model.project.Project;
+import seedu.address.model.project.ProjectId;
 import seedu.address.model.tag.exceptions.IllegalValueException;
 
 /**
@@ -26,7 +28,6 @@ class JsonAdaptedIssue {
     private final String deadline;
     private final String status;
     private final String issueId;
-
     private final String project;
 
     /**
@@ -79,19 +80,23 @@ class JsonAdaptedIssue {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     Priority.class.getSimpleName()));
         }
-        //        if (!Priority.isValidPriority(priority)) {
-        //            throw new IllegalValueException(Priority.MESSAGE_CONSTRAINTS);
-        //        }
+
+        if (!Priority.isValidPriorityString(priority)) {
+            throw new IllegalValueException(Priority.MESSAGE_CONSTRAINTS);
+        }
+
         final Priority modelPriority = Priority.valueOf(priority);
 
         Deadline modelDeadline;
+
+        if (deadline == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Deadline.class.getSimpleName()));
+        }
+
         if (deadline.isEmpty()) {
             modelDeadline = Deadline.EmptyDeadline.EMPTY_DEADLINE;
         } else {
-            if (deadline == null) {
-                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                        Deadline.class.getSimpleName()));
-            }
             if (!Deadline.isValidDeadline(deadline)) {
                 throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
             }
@@ -106,14 +111,17 @@ class JsonAdaptedIssue {
         }
         final Status modelStatus = new Status(Boolean.valueOf(status));
 
-        //        if (project == null) {
-        //            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-        //            Project.class.getSimpleName()));
-        //        }
-        //
-        final Project modelProject = HasIntegerIdentifier.getElementById(
-                addressBook.getProjectList(), Integer.parseInt(project));
-
+        if (project == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+            Project.class.getSimpleName()));
+        }
+        final Project modelProject;
+        try {
+            modelProject = HasIntegerIdentifier.getElementById(
+                    addressBook.getProjectList(), Integer.parseInt(project));
+        } catch (NotFoundException e) {
+            throw new IllegalValueException(ProjectId.MESSAGE_CONSTRAINTS);
+        }
 
         if (issueId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, IssueId.class.getSimpleName()));
@@ -122,6 +130,8 @@ class JsonAdaptedIssue {
             throw new IllegalValueException(IssueId.MESSAGE_CONSTRAINTS);
         }
         final IssueId modelIssueId = new IssueId(Integer.parseInt(issueId));
+
+        assert modelIssueId.getIdInt() >= 0 : "Issue ID should be positive";
 
         return new Issue(modelDescription, modelDeadline, modelPriority, modelStatus, modelProject, modelIssueId);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedIssue.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedIssue.java
@@ -84,14 +84,19 @@ class JsonAdaptedIssue {
         //        }
         final Priority modelPriority = Priority.valueOf(priority);
 
-        if (deadline == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    Deadline.class.getSimpleName()));
+        Deadline modelDeadline;
+        if (deadline.isEmpty()) {
+            modelDeadline = Deadline.EmptyDeadline.EMPTY_DEADLINE;
+        } else {
+            if (deadline == null) {
+                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                        Deadline.class.getSimpleName()));
+            }
+            if (!Deadline.isValidDeadline(deadline)) {
+                throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
+            }
+            modelDeadline = new Deadline(deadline);
         }
-        if (!Deadline.isValidDeadline(deadline)) {
-            throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
-        }
-        final Deadline modelDeadline = new Deadline(deadline);
 
         if (status == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -81,13 +81,13 @@ class JsonAdaptedProject {
         final Name modelName = new Name(name);
 
         Repository modelRepository;
+        if (repository == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Repository.class.getSimpleName()));
+        }
         if (repository.isEmpty()) {
             modelRepository = Repository.EmptyRepository.EMPTY_REPOSITORY;
         } else {
-            if (repository == null) {
-                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                        Repository.class.getSimpleName()));
-            }
             if (!Repository.isValidRepository(repository)) {
                 throw new IllegalValueException(Repository.MESSAGE_CONSTRAINTS);
             }
@@ -95,13 +95,13 @@ class JsonAdaptedProject {
         }
 
         Deadline modelDeadline;
+        if (deadline == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Deadline.class.getSimpleName()));
+        }
         if (deadline.isEmpty()) {
             modelDeadline = Deadline.EmptyDeadline.EMPTY_DEADLINE;
         } else {
-            if (deadline == null) {
-                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                        Deadline.class.getSimpleName()));
-            }
             if (!Deadline.isValidDeadline(deadline)) {
                 throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
             }
@@ -112,8 +112,8 @@ class JsonAdaptedProject {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Project.class.getSimpleName()));
         }
 
-        //TODO: Implement empty client parsing from storage
         final Client modelClient = client.toModelType();
+
         final List<Issue> modelIssues = new ArrayList<>();
 
         if (projectId == null) {
@@ -124,6 +124,8 @@ class JsonAdaptedProject {
             throw new IllegalValueException(ProjectId.MESSAGE_CONSTRAINTS);
         }
         final ProjectId modelProjectId = new ProjectId(Integer.parseInt(projectId));
+
+        assert modelProjectId.getIdInt() >= 0 : "Project ID should be positive";
 
         return new Project(modelName, modelRepository, modelDeadline, modelClient, modelIssues, modelProjectId);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedProject.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedProject.java
@@ -80,28 +80,39 @@ class JsonAdaptedProject {
         }
         final Name modelName = new Name(name);
 
-        if (repository == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    Repository.class.getSimpleName()));
+        Repository modelRepository;
+        if (repository.isEmpty()) {
+            modelRepository = Repository.EmptyRepository.EMPTY_REPOSITORY;
+        } else {
+            if (repository == null) {
+                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                        Repository.class.getSimpleName()));
+            }
+            if (!Repository.isValidRepository(repository)) {
+                throw new IllegalValueException(Repository.MESSAGE_CONSTRAINTS);
+            }
+            modelRepository = new Repository(repository);
         }
-        if (!Repository.isValidRepository(repository)) {
-            throw new IllegalValueException(Repository.MESSAGE_CONSTRAINTS);
-        }
-        final Repository modelRepository = new Repository(repository);
 
-        if (deadline == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    Deadline.class.getSimpleName()));
+        Deadline modelDeadline;
+        if (deadline.isEmpty()) {
+            modelDeadline = Deadline.EmptyDeadline.EMPTY_DEADLINE;
+        } else {
+            if (deadline == null) {
+                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                        Deadline.class.getSimpleName()));
+            }
+            if (!Deadline.isValidDeadline(deadline)) {
+                throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
+            }
+            modelDeadline = new Deadline(deadline);
         }
-        if (!Deadline.isValidDeadline(deadline)) {
-            throw new IllegalValueException(Deadline.MESSAGE_CONSTRAINTS);
-        }
-        final Deadline modelDeadline = new Deadline(deadline);
 
         if (client == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Project.class.getSimpleName()));
         }
 
+        //TODO: Implement empty client parsing from storage
         final Client modelClient = client.toModelType();
         final List<Issue> modelIssues = new ArrayList<>();
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -70,6 +70,8 @@ class JsonSerializableAddressBook {
             }
         }
 
+        addressBook.sortClientListById();
+
         for (JsonAdaptedIssue jsonAdaptedIssue : issues) {
             Issue issue = jsonAdaptedIssue.toModelType(addressBook);
             if (addressBook.hasIssue(issue)) {

--- a/src/main/java/seedu/address/ui/ClientCard.java
+++ b/src/main/java/seedu/address/ui/ClientCard.java
@@ -47,8 +47,8 @@ public class ClientCard extends UiPart<Region> {
         this.client = client;
         // id.setText(displayedIndex + ". ");
         name.setText(client.getClientName().toString() + " " + client.getClientId().uiRepresentation());
-        phone.setText(client.getClientPhone().getPhoneRepresentation());
-        email.setText(client.getClientEmail().getEmailRepresentation());
+        phone.setText(client.getClientPhone().uiRepresentation());
+        email.setText(client.getClientEmail().uiRepresentation());
         client.getProjects().stream()
                 .sorted(Comparator.comparing(project -> project.getProjectName().toString()))
                 .forEach(project -> projects.getChildren().add(new Label(project.getProjectName().toString())));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -53,9 +53,9 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().toString());
-        phone.setText(person.getPhone().getPhoneRepresentation());
+        phone.setText(person.getPhone().uiRepresentation());
         address.setText(person.getAddress().value);
-        email.setText(person.getEmail().getEmailRepresentation());
+        email.setText(person.getEmail().uiRepresentation());
 
         // TODO: Remove tags once decided on Client implementation
         person.getTags().stream()


### PR DESCRIPTION
### Problem
Empty attributes e.g. `EmptyDeadline`, `EmptyRepository` were being incorrectly loaded from `Storage` as actual `Deadline` instances.


### Solution
When saving to storage, empty attributes will now be saved as an empty `String`. When reading from `Storage`, `JsonSerializableAddressBook` will now check for empty `String` and parse it into its respective empty attribute singleton class.