### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/client/EditClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/client/EditClientCommand.java
@@ -74,7 +74,7 @@ public class EditClientCommand extends ClientCommand {
 
         if (newName != null) {
             for (Client c : model.getFilteredClientList()) {
-                if (c.getClientName().equals(newName)) {
+                if (c.getClientName().equals(newName.setCapitalise())) {
                     throw new CommandException(MESSAGE_DUPLICATE_CLIENT_NAME);
                 }
             }

--- a/src/main/java/seedu/address/logic/commands/client/EditClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/client/EditClientCommand.java
@@ -31,6 +31,8 @@ public class EditClientCommand extends ClientCommand {
 
     public static final String MESSAGE_CLIENT_NOT_FOUND = "Client id %1$d does not exist in the project book";
 
+    public static final String MESSAGE_CLIENT_ALREADY_HAS_THAT_NAME = "This client already has that name";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + " " + COMMAND_FLAG
             + ": Edits a client in the project book. \n"
@@ -75,6 +77,9 @@ public class EditClientCommand extends ClientCommand {
         if (newName != null) {
             for (Client c : model.getFilteredClientList()) {
                 if (c.getClientName().equals(newName.setCapitalise())) {
+                    if (toEditClient.getClientName().equals(newName.setCapitalise())) {
+                        throw new CommandException(MESSAGE_CLIENT_ALREADY_HAS_THAT_NAME);
+                    }
                     throw new CommandException(MESSAGE_DUPLICATE_CLIENT_NAME);
                 }
             }

--- a/src/main/java/seedu/address/logic/commands/project/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/project/EditProjectCommand.java
@@ -51,6 +51,7 @@ public class EditProjectCommand extends ProjectCommand {
     public static final String MESSAGE_PROJECT_NOT_FOUND = "Project id %1$d does not exist in the project book";
     public static final String MESSAGE_DUPLICATE_PROJECT_NAME = "A project with this name already "
             + "exists in the project book";
+    public static final String MESSAGE_PROJECT_ALREADY_HAS_THAT_NAME = "This project already has that name";
 
     private final ProjectId projectToEditId;
     private final Name newName;
@@ -86,6 +87,9 @@ public class EditProjectCommand extends ProjectCommand {
         if (newName != null) {
             for (Project p : model.getFilteredProjectList()) {
                 if (p.getProjectName().equals(newName.setCapitalise())) {
+                    if (toEditProject.getProjectName().equals(newName.setCapitalise())) {
+                        throw new CommandException(MESSAGE_PROJECT_ALREADY_HAS_THAT_NAME);
+                    }
                     throw new CommandException(MESSAGE_DUPLICATE_PROJECT_NAME);
                 }
             }

--- a/src/main/java/seedu/address/logic/commands/project/EditProjectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/project/EditProjectCommand.java
@@ -85,7 +85,7 @@ public class EditProjectCommand extends ProjectCommand {
 
         if (newName != null) {
             for (Project p : model.getFilteredProjectList()) {
-                if (p.getProjectName().equals(newName)) {
+                if (p.getProjectName().equals(newName.setCapitalise())) {
                     throw new CommandException(MESSAGE_DUPLICATE_PROJECT_NAME);
                 }
             }
@@ -104,7 +104,9 @@ public class EditProjectCommand extends ProjectCommand {
             }
         }
 
-        toEditProject.setName(newName);
+        if (newName != null) {
+            toEditProject.setName(newName);
+        }
 
         if (newRepository != null) {
             toEditProject.setRepository(newRepository);

--- a/src/main/java/seedu/address/model/Name.java
+++ b/src/main/java/seedu/address/model/Name.java
@@ -1,7 +1,10 @@
 package seedu.address.model;
 
+import static java.lang.Character.isLetter;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Represents the name of the client. This class is modelled after the Name class in the Person package of AB3
@@ -54,6 +57,16 @@ public class Name {
         }
     }
 
+    /**
+     * Capitalises the name.
+     */
+    public Name setCapitalise() {
+        if (isLetter(getFullNameRepresentation().charAt(0))) {
+            this.fullName = getFullNameRepresentation().substring(0, 1).toUpperCase()
+                    + getFullNameRepresentation().substring(1);
+        }
+        return this;
+    }
 
     /**
      * Returns true if a given string is a valid name. A name is valid only if it contains only letters and spaces and

--- a/src/main/java/seedu/address/model/Name.java
+++ b/src/main/java/seedu/address/model/Name.java
@@ -4,8 +4,6 @@ import static java.lang.Character.isLetter;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Represents the name of the client. This class is modelled after the Name class in the Person package of AB3
  */

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -233,7 +233,11 @@ public class Client implements ComparableByName<Client>, HasIntegerIdentifier<Cl
      * @return String for display in the UI
      */
     public String uiRepresentation() {
-        return this.name.toString() + this.mobile.toString();
+        return this.name.toString() + clientMobileRepresentation();
+    }
+
+    public String clientMobileRepresentation() {
+        return this.mobile.isEmpty() ? this.mobile.toString() : " (" + this.mobile.toString() + ")";
     }
 
     public void removeProject(Project p) {

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -233,7 +233,7 @@ public class Client implements ComparableByName<Client>, HasIntegerIdentifier<Cl
      * @return String for display in the UI
      */
     public String uiRepresentation() {
-        return this.name.toString() + " (" + this.mobile.toString() + ")";
+        return this.name.toString() + this.mobile.toString();
     }
 
     public void removeProject(Project p) {

--- a/src/main/java/seedu/address/model/client/ClientMobile.java
+++ b/src/main/java/seedu/address/model/client/ClientMobile.java
@@ -83,7 +83,7 @@ public class ClientMobile {
      */
     @Override
     public String toString() {
-        return " (" + this.mobile.toString() + ")";
+        return this.mobile;
     }
     /**
      * Checks if an object equals this.

--- a/src/main/java/seedu/address/model/client/ClientMobile.java
+++ b/src/main/java/seedu/address/model/client/ClientMobile.java
@@ -83,7 +83,7 @@ public class ClientMobile {
      */
     @Override
     public String toString() {
-        return this.mobile;
+        return " (" + this.mobile.toString() + ")";
     }
     /**
      * Checks if an object equals this.

--- a/src/main/java/seedu/address/model/client/ClientWithoutModel.java
+++ b/src/main/java/seedu/address/model/client/ClientWithoutModel.java
@@ -36,7 +36,7 @@ public class ClientWithoutModel implements Function<Model, Client> {
 
     public ClientWithoutModel(Name name, ClientMobile mobile, ClientEmail email,
                               List<ProjectId> projectIdList, Pin pin) {
-        this.name = name;
+        this.name = name.setCapitalise();
         this.mobile = mobile;
         this.email = email;
         this.projectIdList = projectIdList;

--- a/src/main/java/seedu/address/model/project/ProjectWithoutModel.java
+++ b/src/main/java/seedu/address/model/project/ProjectWithoutModel.java
@@ -39,7 +39,7 @@ public class ProjectWithoutModel implements Function<Model, Project> {
      */
     public ProjectWithoutModel(Name name, Repository repository, Deadline deadline,
                                ClientId clientId, List<Issue> issueList, Pin pin) {
-        this.name = name;
+        this.name = name.setCapitalise();
         this.repository = repository;
         this.deadline = deadline;
         this.clientId = clientId;


### PR DESCRIPTION
For incorrect error message displayed for renaming to the same name as itself on edit project and edit client
For crash when edit project name parameter is null
For incorrect display of () without a client contact number
For incorrect adding of projects and clients with a name that is already present of different case sensitivity (Resolved by making first letter of projects capitalised)